### PR TITLE
CSV import

### DIFF
--- a/js/Worksheet.js
+++ b/js/Worksheet.js
@@ -361,7 +361,7 @@ class Worksheet extends HTMLElement {
         externalLinkButton.addEventListener("dragstart", this.onExternalLinkDragStart);
         this.removeEventListener("dragover", this.onDragOver);
         this.addEventListener("dragleave", this.onDragLeave);
-        this.removeEventListenere("drop", this.onDrop);
+        this.removeEventListener("drop", this.onDrop);
     }
 
     onMouseDownInHeader(){
@@ -420,7 +420,7 @@ class Worksheet extends HTMLElement {
         const header = this.shadowRoot.querySelector('#header-bar');
         const nameSpan = header.querySelector('#title > span');
         nameSpan.classList.add("hide");
-        const input = header.querySelector('input');
+        const input = header.querySelector('#title > input');
         input.classList.add('show');
         input.value = this.name;
         input.addEventListener('keydown', this.onNameKeydown);
@@ -431,7 +431,7 @@ class Worksheet extends HTMLElement {
     stopEditingName(){
         this.isEditingName = false;
         const header = this.shadowRoot.querySelector('#header-bar');
-        const input = header.querySelector('input');
+        const input = header.querySelector('#title > input');
         const nameSpan = header.querySelector('#title > span');
         nameSpan.classList.remove("hide");
         input.removeEventListener('keydown', this.onNameKeydown);
@@ -496,10 +496,13 @@ class Worksheet extends HTMLElement {
     }
 
     onRun(){
-        if(!this.getAttribute("sources") || this.getAttribute("targets")){
+        if(!this.getAttribute("sources") || !this.getAttribute("targets")){
             alert("You must have both sources and targets set to run!");
         }
-        this.callStack.runAll(this.getAttribute("sources"), this.getAttribute("targets"));
+        this.callStack.runAll(
+            this.getAttribute("sources").split(","),
+            this.getAttribute("targets").split(",")
+        );
     }
 
     onExternalLinkDragStart(event){

--- a/js/utils/icons.js
+++ b/js/utils/icons.js
@@ -82,6 +82,14 @@ const unlink = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler 
   <line x1="8" y1="3" x2="8" y2="5" />
 </svg>`;
 
+const fileUpload = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-file-upload" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+  <line x1="12" y1="11" x2="12" y2="17" />
+  <polyline points="9 14 12 11 15 14" />
+</svg>`;
+
 const icons = {
     eraser: eraser,
     remove: remove,
@@ -93,6 +101,7 @@ const icons = {
     trash: trash,
     link: link,
     unlink: unlink,
+    fileUpload: fileUpload
 }
 
 

--- a/js/utils/icons.js
+++ b/js/utils/icons.js
@@ -56,6 +56,32 @@ const sheetExport= `<svg xmlns="http://www.w3.org/2000/svg" id="sheet-export" cl
   <path d="M11.5 20h-5.5a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v7.5m-16 -3.5h16m-10 -6v16m4 -1h7m-3 -3l3 3l-3 3" />
 </svg>`;
 
+const trash = `<svg xmlns="http://www.w3.org/2000/svg" id="trash" class="icon icon-tabler icon-tabler-trash" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <line x1="4" y1="7" x2="20" y2="7" />
+  <line x1="10" y1="11" x2="10" y2="17" />
+  <line x1="14" y1="11" x2="14" y2="17" />
+  <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12" />
+  <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />
+</svg>`;
+
+const link = `<svg xmlns="http://www.w3.org/2000/svg" id="link" class="icon icon-tabler icon-tabler-link" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" />
+  <path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" />
+</svg>`;
+
+
+const unlink = `<svg xmlns="http://www.w3.org/2000/svg" id="unlink" class="icon icon-tabler icon-tabler-unlink" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" />
+  <path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" />
+  <line x1="16" y1="21" x2="16" y2="19" />
+  <line x1="19" y1="16" x2="21" y2="16" />
+  <line x1="3" y1="8" x2="5" y2="8" />
+  <line x1="8" y1="3" x2="8" y2="5" />
+</svg>`;
+
 const icons = {
     eraser: eraser,
     remove: remove,
@@ -64,6 +90,9 @@ const icons = {
     externalLink: externalLink,
     sheetImport: sheetImport,
     sheetExport: sheetExport,
+    trash: trash,
+    link: link,
+    unlink: unlink,
 }
 
 

--- a/js/utils/icons.js
+++ b/js/utils/icons.js
@@ -5,14 +5,14 @@
 
 
 const eraser= `
-<svg xmlns="http://www.w3.org/2000/svg" id="erase" class="icon icon-tabler icon-tabler-eraser" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-eraser" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <path d="M19 19h-11l-4 -4a1 1 0 0 1 0 -1.41l10 -10a1 1 0 0 1 1.41 0l5 5a1 1 0 0 1 0 1.41l-9 9" />
   <line x1="18" y1="12.3" x2="11.7" y2="6" />
 </svg>`;
 
 const remove= `
-<svg xmlns="http://www.w3.org/2000/svg" id="remove" class="icon icon-tabler icon-tabler-square-x" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-square-x" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <rect x="4" y="4" width="16" height="16" rx="2" />
   <path d="M10 10l4 4m0 -4l-4 4" />
@@ -20,7 +20,7 @@ const remove= `
 
 
 const sheet= `
-<svg xmlns="http://www.w3.org/2000/svg" id="sheet" class="icon icon-tabler icon-tabler-table" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-table" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <rect x="4" y="4" width="16" height="16" rx="2" />
   <line x1="4" y1="10" x2="20" y2="10" />
@@ -29,7 +29,7 @@ const sheet= `
 
 
 const run= `
-<svg xmlns="http://www.w3.org/2000/svg" id="run" class="icon icon-tabler icon-tabler-run" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-run" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <circle cx="13" cy="4" r="1" />
   <path d="M4 17l5 1l.75 -1.5" />
@@ -39,24 +39,24 @@ const run= `
 
 
 const externalLink= `
-<svg xmlns="http://www.w3.org/2000/svg" id="external-link" class="icon icon-tabler icon-tabler-external-link" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-external-link" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" />
   <line x1="10" y1="14" x2="20" y2="4" />
   <polyline points="15 4 20 4 20 9" />
 </svg>`;
 
-const sheetImport= `<svg xmlns="http://www.w3.org/2000/svg" id="sheet-import" class="icon icon-tabler icon-tabler-table-import" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+const sheetImport= `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-table-import" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <path d="M4 13.5v-7.5a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-6m-8 -10h16m-10 -6v11.5m-8 3.5h7m-3 -3l3 3l-3 3" />
 </svg>`;
 
-const sheetExport= `<svg xmlns="http://www.w3.org/2000/svg" id="sheet-export" class="icon icon-tabler icon-tabler-table-export" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+const sheetExport= `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-table-export" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <path d="M11.5 20h-5.5a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v7.5m-16 -3.5h16m-10 -6v16m4 -1h7m-3 -3l3 3l-3 3" />
 </svg>`;
 
-const trash = `<svg xmlns="http://www.w3.org/2000/svg" id="trash" class="icon icon-tabler icon-tabler-trash" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+const trash = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-trash" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <line x1="4" y1="7" x2="20" y2="7" />
   <line x1="10" y1="11" x2="10" y2="17" />
@@ -65,14 +65,14 @@ const trash = `<svg xmlns="http://www.w3.org/2000/svg" id="trash" class="icon ic
   <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />
 </svg>`;
 
-const link = `<svg xmlns="http://www.w3.org/2000/svg" id="link" class="icon icon-tabler icon-tabler-link" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+const link = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-link" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" />
   <path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" />
 </svg>`;
 
 
-const unlink = `<svg xmlns="http://www.w3.org/2000/svg" id="unlink" class="icon icon-tabler icon-tabler-unlink" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+const unlink = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-unlink" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" />
   <path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" />


### PR DESCRIPTION
### Main points ###

You can now import files into the Worksheet (currently restricted to csv). There are two ways to do this:

* Clicking on the upload file icon:
![image](https://user-images.githubusercontent.com/1154326/171163367-1dd4886d-f38e-44c9-9b75-71e3b4028b6f.png)
which brings up the classic browser file input search box
![image](https://user-images.githubusercontent.com/1154326/171163506-2da6f642-55d1-4ee6-8b70-40fbddbb6b68.png)

or 
* via drag and drop
which brings up an upload icon overlay:
![image](https://user-images.githubusercontent.com/1154326/171163675-ecb00611-5457-495b-a609-fc369a56d108.png)


Moreover, worksheet linking (source and target) now brings up a link icon overlay on the drag over target sheet:
![image](https://user-images.githubusercontent.com/1154326/171163904-b177cd53-7894-48f2-928d-99b35bb08e04.png)


In order for this to work properly I needed to detect what kind of drop is happening (link or file), which can be touchy as seen [here](https://github.com/dkrasner/TableMapper/compare/daniel-import-csvv?expand=1#diff-d63b3e5baa408a9520b175842c16e48cf325e2556b82434ad808f0d17bf7a135R516)

Note: this branch is rebased over #8 since I needed the icon wrapping and related methods, and figured it was best not to clash. 

#### Known Issues ####
Importing a csv causes the underlying sheet to collapse, sometimes to one row sometimes to one column. This does not seem to be an issue with Worksheet but with the underlying sheet as discussed [here](https://github.com/darth-cheney/ap-sheet/pull/15#issuecomment-1141904259)